### PR TITLE
Support non-default port with SSH

### DIFF
--- a/trackers/ssh_tracker.py
+++ b/trackers/ssh_tracker.py
@@ -56,21 +56,21 @@ class ssh_tracker(tracker):
 					Domoticz.Error(self.tracker_ip + ' ====> SSH Could not get RSA from private key. Exception: ' + str(e))
 				Domoticz.Debug(self.tracker_ip + ' ====> SSH using key: ' + str(my_key_file))
 				try:
-					self.client.connect(self.tracker_ip, username=self.tracker_user, pkey=rsa_key, timeout=5)
+					self.client.connect(self.tracker_ip, port=self.tracker_port, username=self.tracker_user, pkey=rsa_key, timeout=5)
 				except Exception as e:
 					Domoticz.Error(self.tracker_ip + ' SSH Could not connect (using custom key file). Exception: ' + str(e))
 					self.connected = False
 					return
 			else:
 				try:
-					self.client.connect(self.tracker_ip, username=self.tracker_user, timeout=5)
+					self.client.connect(self.tracker_ip, port=self.tracker_port, username=self.tracker_user, timeout=5)
 				except Exception as e:
 					Domoticz.Error(self.tracker_ip + ' SSH Could not connect (with os key). Exception: ' + str(e))
 					self.connected = False
 					return False
 		else:
 			try:
-				self.client.connect(self.tracker_ip, username=self.tracker_user, password=self.tracker_password, timeout=5)
+				self.client.connect(self.tracker_ip, port=self.tracker_port, username=self.tracker_user, password=self.tracker_password, look_for_keys=False, timeout=5)
 			except Exception as e:
 				Domoticz.Error(self.tracker_ip + ' ====> SSH Could not connect (using password). Exception: ' + str(e))
 				self.connected = False


### PR DESCRIPTION
The base-plugin suggests that you can use a different port than the default one (22), but the port set is not used anywhere in the plugin, so here my pull request to add this support.

I also add the "look_for_keys" option set to false for password only connection. Because without that It's not possible to connect to my routerOS.