### PR TITLE
Added a specific callback for handling ARP on RouterOS

### DIFF
--- a/trackers/ssh_routeros_arp.py
+++ b/trackers/ssh_routeros_arp.py
@@ -5,8 +5,8 @@ import helpers.data_helper as data_helper
 import re
 from datetime import datetime
 
-ARP_PATTERN_MAC = r'(?=.*\bDC\b)(?:\S+ ){3}(\S+)'
-ARP_PATTERN_IP = r'(?=.*\bDC\b)(?:\S+ ){2}(\S+)'
+ARP_PATTERN_MAC = r'(?=.*\bDC\b|.*\b C\b)(?:\S+ ){3}(\S+)'
+ARP_PATTERN_IP = r'(?=.*\bDC\b|.*\b C\b)(?:\S+ ){2}(\S+)'
 
 def remove_white_space(data):
 	this_data = re.sub(' +', ' ',data)

--- a/trackers/ssh_routeros_arp.py
+++ b/trackers/ssh_routeros_arp.py
@@ -1,11 +1,52 @@
+import Domoticz
 from trackers.ssh_tracker import ssh_tracker
 import helpers.tracker_cli_helper as tracker_cli_helper
+import helpers.data_helper as data_helper
+import re
+from datetime import datetime
+
+ARP_PATTERN_MAC = r'(?=.*\bDC\b)(?:\S+ ){3}(\S+)'
+ARP_PATTERN_IP = r'(?=.*\bDC\b)(?:\S+ ){2}(\S+)'
+
+def remove_white_space(data):
+	this_data = re.sub(' +', ' ',data)
+	return this_data
+
+def clean_tag_id_list_arp(raw_data, tag_type):
+	if isinstance(raw_data, list):
+		raw_list = raw_data
+	else:
+		raw_data = remove_white_space(raw_data)
+		raw_data = raw_data.upper()
+		if tag_type == 'mac_address':
+			match_this = re.compile(ARP_PATTERN_MAC)
+		elif tag_type == 'ip_address':
+			match_this = re.compile(ARP_PATTERN_IP)
+		else:
+			Domoticz.Error('Undefined tag_type for data: ' + raw_data)
+			return []
+		raw_list = match_this.findall(raw_data)
+	clean_list = [data_helper.clean_tag(x) for x in raw_list]
+	return clean_list
 
 class ssh_routeros_arp(ssh_tracker):
 	def __init__(self, tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval):
 		super().__init__(tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval)
 		self.prepare_for_polling()
+		self.tag_type = 'mac_address'
 
 	def prepare_for_polling(self):
+		Domoticz.Debug('routeros-arp prepare_for_polling')
 		self.trackerscript = "ip arp print"
 		self.is_ready = True
+
+	def receiver_callback(self, raw_data):
+		Domoticz.Debug('routeros-arp receiver_callback called')
+		#Domoticz.Debug(raw_data + ' raw_data')
+		#Domoticz.Debug(self.tag_type + ' self.tag_type')
+		self.found_tag_ids = clean_tag_id_list_arp(raw_data, self.tag_type)
+		if not self.interpreter_callback is None:
+			self.interpreter_callback(self)
+		else:
+			Domoticz.Debug(self.tracker_ip + ' No interpreter_callback registered. Ignoring new data.')
+

--- a/trackers/ssh_routeros_arp.py
+++ b/trackers/ssh_routeros_arp.py
@@ -33,7 +33,6 @@ class ssh_routeros_arp(ssh_tracker):
 	def __init__(self, tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval):
 		super().__init__(tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval)
 		self.prepare_for_polling()
-		self.tag_type = 'mac_address'
 
 	def prepare_for_polling(self):
 		Domoticz.Debug('routeros-arp prepare_for_polling')


### PR DESCRIPTION
OK, let's check an example

>[XXXXXX@MikroTik-CCR1072-1G-8S+] /ip arp> print
Flags: X - disabled, I - invalid, H - DHCP, D - dynamic, P - published, C - complete
 '#    ADDRESS         MAC-ADDRESS       INTERFACE
 0  C   XXX.XXX.XXX.AAA   FF:FF:FF:FF:FF:FF bridge
 1 DC XXX.XXX.XXX.BBB    AA:D0:F6:00:C4:F8 bridgePrio6
 2 DC XXX.XXX.XXX.CCC    BB:5E:BE:27:54:BC bridge
 3 DC XXX.XXX.XXX.DDD    CC:17:88:00:DF:35 bridge
 4 DC XXX.XXX.XXX.XXX    DD:04:4B:5C:A2:2E bridge
 5 D   XXX.XXX.XXX.XXX                                  bridge
 6 D   XXX.XXX.XXX.XXX    FF:6C:63:58:00:5E bridge


Line 5 and 6 are not connected to the network (line 6 just disconnected 1min ago from network)

> [XXXXXX@MikroTik-CCR1072-1G-8S+] /ip arp> print
Flags: X - disabled, I - invalid, H - DHCP, D - dynamic, P - published, C - complete
 '#    ADDRESS         MAC-ADDRESS       INTERFACE
 0  C   XXX.XXX.XXX.AAA   FF:FF:FF:FF:FF:FF bridge
 1 DC XXX.XXX.XXX.BBB    AA:D0:F6:00:C4:F8 bridgePrio6
 2 DC XXX.XXX.XXX.CCC    BB:5E:BE:27:54:BC bridge
 3 DC XXX.XXX.XXX.DDD    CC:17:88:00:DF:35 bridge
 4 DC XXX.XXX.XXX.XXX    DD:04:4B:5C:A2:2E bridge
 5 DC XXX.XXX.XXX.XXX   EE:6E:BF:63:00:08 bridge
 6 DC XXX.XXX.XXX.XXX    FF:6C:63:58:00:5E bridge


Everyone is connected.

Without this implementation, you can't check the device presence using the routerOS arp command. Because as long as RouterOS keep the MAC in cache, iDetect would consider the device online.

So I edited the regex roughly (sorry I'm not a regex master!) to gather MACID which have the C flags in order to select the four first MACID in the first example instead of all five.
