### PR TITLE
Adding getting clients from /tmp/clientlist.json for ASUS AiMesh

### DIFF
--- a/trackers/__init__.py
+++ b/trackers/__init__.py
@@ -9,6 +9,7 @@ from trackers.ssh_routeros_capsman import ssh_routeros_capsman
 from trackers.ssh_routeros_arp import ssh_routeros_arp
 from trackers.ssh_zyxel_arp import ssh_zyxel_arp
 from trackers.ssh_unifi_usg_arp import ssh_unifi_usg_arp
+from trackers.ssh_aimesh_json import ssh_aimesh_json
 from trackers.http_orbi import http_orbi
 from trackers.http_unifi import http_unifi
 from trackers.http_omada import http_omada
@@ -23,6 +24,7 @@ poll_methods = {
 	'routeros-capsman': ssh_routeros_capsman,
     'zyxel-arp': ssh_zyxel_arp,
     'unifiusg-arp': ssh_unifi_usg_arp,
+	'aimesh_json' : ssh_aimesh_json,
     'unifi-http': http_unifi,
     'orbi-http': http_orbi,
     'omada-http': http_omada,

--- a/trackers/ssh_aimesh_json.py
+++ b/trackers/ssh_aimesh_json.py
@@ -5,7 +5,7 @@
 from trackers.ssh_tracker import ssh_tracker
 import helpers.tracker_cli_helper as tracker_cli_helper
 
-class ssh_brctl(ssh_tracker):
+class ssh_aimesh_json(ssh_tracker):
 	def __init__(self, tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval):
 		super().__init__(tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval)
 		self.prepare_for_polling()

--- a/trackers/ssh_aimesh_json.py
+++ b/trackers/ssh_aimesh_json.py
@@ -1,0 +1,15 @@
+# On ASUS AiMesh architecture, then "main" router (the one connected to the WAN, even if alone) has a temp file
+# that stores all the "clients" connected to the mesh.
+# Thanks to Fireport https://www.domoticz.com/forum/viewtopic.php?f=65&t=20467&p=239509&hilit=json+cat+%2Ftmp%2Fclientlist.json#p239509
+
+from trackers.ssh_tracker import ssh_tracker
+import helpers.tracker_cli_helper as tracker_cli_helper
+
+class ssh_brctl(ssh_tracker):
+	def __init__(self, tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval):
+		super().__init__(tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval)
+		self.prepare_for_polling()
+
+	def prepare_for_polling(self):
+		self.trackerscript = "cat /tmp/clientlist.json"
+		self.is_ready = True


### PR DESCRIPTION
On ASUS AiMesh architecture, then "main" router (the one connected to the WAN, even if alone) has a temp file that stores all the "clients" connected to the mesh.

Thanks to Fireport https://www.domoticz.com/forum/viewtopic.php?f=65&t=20467&p=239509&hilit=json+cat+%2Ftmp%2Fclientlist.json#p239509
