### PR TITLE
Update http_orbi.py

### DIFF
--- a/trackers/http_orbi.py
+++ b/trackers/http_orbi.py
@@ -10,8 +10,8 @@ class http_orbi(tracker):
 	def __init__(self, tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval):
 		super().__init__(tracker_ip, tracker_port, tracker_user, tracker_password, tracker_keyfile, poll_interval)
 		if not tracker_port:
-			tracker_port = 443
-		self.orbi_url = 'https://{}:{}/DEV_device_info.htm'.format(self.tracker_ip, self.tracker_port)
+			tracker_port = 80
+		self.orbi_url = 'http://{}:{}/DEV_device_info.htm'.format(self.tracker_ip, self.tracker_port)
 		self.http_session = None
 		self.prepare_for_polling()
 		


### PR DESCRIPTION
As there is no way to create Issue to discuss problem , I'm using the PR way.

Why is it force to use https/443. I own an Orbi and for sure the https doesn't work and especially to get the DEV_info

Could you clarify what is the reason why it has been coded like that ? Is there some Orbi which works with https ?